### PR TITLE
Introduce new ColonistProcessor optimizations

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -5,7 +5,7 @@ ext {
 
   jsr305Version = '3.0.2'
   asmVersion = '9.2'
-  gripVersion = '0.8.0'
+  gripVersion = '0.8.2'
   logbackVersion = '1.2.3'
 
   junitVersion = '4.13.2'


### PR DESCRIPTION
This PR introduces two new optimizations to ColonistProcessor:
- Grip instance is now "warmed up" which means all its ClassMirrors processed eagerly and in parallel.
- Colony settlers are now computed in parallel for different Colony markers. 

These optimizations allows us to save ~1 second of time (or ~30% in relative numbers) in our project.