### PR TITLE
Publish using gradle-nexus.publish-plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,8 @@ on: [ push, pull_request ]
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
   PABLO_OPTS: |
-    -Ppablo.repository.maven.name=Sonatype \
-    -Ppablo.repository.maven.url=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/ \
-    -Ppablo.repository.maven.username=${{ secrets.SONATYPE_USERNAME }} \
-    -Ppablo.repository.maven.password=${{ secrets.SONATYPE_PASSWORD }} \
+    -PsonatypeUsername=${{ secrets.SONATYPE_USERNAME }} \
+    -PsonatypePassword=${{ secrets.SONATYPE_PASSWORD }} \
     -Ppablo.signing.keyId=${{ secrets.SIGNING_KEY_ID }} \
     -Ppablo.signing.password=${{ secrets.SIGNING_PASSWORD }} \
     -Ppablo.signing.secretKey='${{ secrets.SIGNING_SECRET_KEY }}'
@@ -88,10 +86,4 @@ jobs:
           java-version: 11
 
       - name: Upload Artifacts
-        run: |
-          ./gradlew -p colonist \
-          annotations:publishMavenPublicationToSonatypeRepository \
-          core:publishMavenPublicationToSonatypeRepository \
-          gradle-plugin:publishMavenPublicationToSonatypeRepository \
-          processor:publishMavenPublicationToSonatypeRepository \
-          -Ppablo.shadow.enabled=true ${{ env.PABLO_OPTS }}
+        run: ./gradlew -p colonist publishToSonatype -Ppablo.shadow.enabled=true ${{ env.PABLO_OPTS }}

--- a/colonist/build.gradle
+++ b/colonist/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 plugins {
   id "org.jlleitschuh.gradle.ktlint" version "10.2.1"
+  id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 allprojects {
@@ -44,6 +45,15 @@ allprojects {
         jvmTarget = "1.8"
         allWarningsAsErrors = true
       }
+    }
+  }
+}
+
+nexusPublishing {
+  repositories {
+    sonatype {
+      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
     }
   }
 }


### PR DESCRIPTION
Using `io.github.gradle-nexus.publish-plugin` instead of `maven-publish`, which is used by `pablo` by default.