### PR TITLE
Kotlin object support

### DIFF
--- a/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/BalaAnt.kt
+++ b/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/BalaAnt.kt
@@ -19,4 +19,4 @@ package com.joom.colonist.modular.ants
 import com.joom.colonist.modular.AntSettler
 
 @AntSettler
-class BalaAnt : NamedAnt("Bala")
+object BalaAnt : NamedAnt("Bala")

--- a/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/ChipAnt.kt
+++ b/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/ChipAnt.kt
@@ -19,4 +19,4 @@ package com.joom.colonist.modular.ants
 import com.joom.colonist.modular.AntSettler
 
 @AntSettler
-class ChipAnt : NamedAnt("Chip")
+object ChipAnt : NamedAnt("Chip")

--- a/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/MuffyAnt.kt
+++ b/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/MuffyAnt.kt
@@ -19,4 +19,4 @@ package com.joom.colonist.modular.ants
 import com.joom.colonist.modular.AntSettler
 
 @AntSettler
-class MuffyAnt : NamedAnt("Muffy")
+object MuffyAnt : NamedAnt("Muffy")

--- a/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/QueenAnt.kt
+++ b/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/QueenAnt.kt
@@ -3,4 +3,4 @@ package com.joom.colonist.modular.ants
 import com.joom.colonist.modular.AntSettler
 
 @AntSettler
-internal class QueenAnt : NamedAnt("Queen")
+object QueenAnt : NamedAnt("Queen")

--- a/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/WeaverAnt.kt
+++ b/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/WeaverAnt.kt
@@ -19,4 +19,4 @@ package com.joom.colonist.modular.ants
 import com.joom.colonist.modular.AntSettler
 
 @AntSettler
-class WeaverAnt : NamedAnt("Weaver")
+object WeaverAnt : NamedAnt("Weaver")

--- a/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/Z4195Ant.kt
+++ b/colonist-samples/sample-kotlin/src/main/java/com/joom/colonist/modular/ants/Z4195Ant.kt
@@ -19,4 +19,4 @@ package com.joom.colonist.modular.ants
 import com.joom.colonist.modular.AntSettler
 
 @AntSettler
-class Z4195Ant : NamedAnt("Z")
+object Z4195Ant : NamedAnt("Z")

--- a/colonist/processor/build.gradle
+++ b/colonist/processor/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(':core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
   implementation "ch.qos.logback:logback-classic:$logbackVersion"
+  implementation "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadata"
 
   relocate "org.ow2.asm:asm:$asmVersion"
   relocate "org.ow2.asm:asm-commons:$asmVersion"

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/analysis/AnnotationMirrorExtensions.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/analysis/AnnotationMirrorExtensions.kt
@@ -25,6 +25,12 @@ inline fun <reified T : Any> AnnotationMirror.requireValue(name: String): T {
   return value
 }
 
+inline fun <reified T : Any> AnnotationMirror.optionalValue(name: String): T? {
+  val value = values[name] ?: return null
+  require(value is T) { "Value $name from $this is of type ${value.javaClass} but expected to have type ${T::class.java}" }
+  return value
+}
+
 fun AnnotationMirror.requireTypeObjectValue(name: String): Type.Object {
   val value = requireValue<Type>(name)
   return value as? Type.Object

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/analysis/SettlerDiscoverer.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/analysis/SettlerDiscoverer.kt
@@ -75,24 +75,24 @@ class SettlerDiscovererImpl(
   }
 
   private fun filterProducibleSettlers(settlers: Collection<Settler>, selector: SettlerSelector, producer: SettlerProducer): Collection<Settler> {
-    return settlers.filter { canBeProducedByProducer(it.type, selector, it.overriddenSettlerProducer ?: producer) }
+    return settlers.filter { canBeProducedByProducer(it, selector, it.overriddenSettlerProducer ?: producer) }
   }
 
-  private fun canBeProducedByProducer(settlerType: Type.Object, selector: SettlerSelector, producer: SettlerProducer): Boolean {
+  private fun canBeProducedByProducer(settler: Settler, selector: SettlerSelector, producer: SettlerProducer): Boolean {
     return when (producer) {
       SettlerProducer.Callback,
       SettlerProducer.Class -> true
       SettlerProducer.Constructor -> {
-        val mirror = grip.classRegistry.getClassMirror(settlerType)
+        val mirror = grip.classRegistry.getClassMirror(settler.type)
 
         if (mirror.isInterface || mirror.isAbstract) {
           return false
         }
 
-        if (mirror.constructors.find { it.isPublic && it.parameters.isEmpty() } == null) {
+        if (mirror.constructors.find { it.isPublic && it.parameters.isEmpty() } == null && !settler.isKotlinObject) {
           errorReporter.reportError(
             "Settler selected by ${selector.describe()} and produced " +
-                "via constructor does not have public default constructor [${settlerType.className}]"
+                "via constructor does not have public default constructor [${settler.type.className}]"
           )
           return false
         }

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/analysis/SettlerParser.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/analysis/SettlerParser.kt
@@ -16,6 +16,7 @@
 
 package com.joom.colonist.processor.analysis
 
+import com.joom.colonist.processor.commons.isKotlinObject
 import com.joom.colonist.processor.model.Settler
 import com.joom.grip.Grip
 import com.joom.grip.mirrors.Type
@@ -34,6 +35,7 @@ class SettlerParserImpl(
     val mirror = grip.classRegistry.getClassMirror(settlerType)
     val settlerProducer = mirror.getSettlerProducerOrNull(settlerProducerParser)
     val settlerAcceptor = mirror.getSettlerAcceptorOrNull(settlerAcceptorParser)
-    return Settler(settlerType, settlerProducer, settlerAcceptor)
+    val isKotlinObject = mirror.isKotlinObject()
+    return Settler(settlerType, isKotlinObject, settlerProducer, settlerAcceptor)
   }
 }

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/commons/Types.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/commons/Types.kt
@@ -34,6 +34,7 @@ import com.joom.grip.mirrors.getObjectType
 object Types {
   val OBJECT_TYPE = getObjectType<Any>()
   val CLASS_TYPE = getObjectType<Class<*>>()
+  val KOTLIN_METADATA_TYPE = getObjectType<Metadata>()
 
   val COLONY_TYPE = getObjectType<Colony>()
   val COLONY_FOUNDER_TYPE = getObjectType<ColonyFounder>()

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/model/Settler.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/model/Settler.kt
@@ -20,6 +20,7 @@ import com.joom.grip.mirrors.Type
 
 data class Settler(
   val type: Type.Object,
+  val isKotlinObject: Boolean,
   val overriddenSettlerProducer: SettlerProducer?,
   val overriddenSettlerAcceptor: SettlerAcceptor?
 )

--- a/colonist/processor/src/test/java/com/joom/colonist/processor/analysis/SettlerDiscovererTest.kt
+++ b/colonist/processor/src/test/java/com/joom/colonist/processor/analysis/SettlerDiscovererTest.kt
@@ -81,6 +81,11 @@ class SettlerDiscovererTest {
   }
 
   @Test
+  fun `kotlin objects selected by annotation without no arg constructor produced via constructor do not raise an error`() {
+    rule.assertValidProject("kotlin_object_by_annotation")
+  }
+
+  @Test
   fun `abstract settlers selected by super type and produced via constructor do not raise an error`() {
     rule.assertValidProject("abstract_by_supertype")
   }
@@ -93,6 +98,11 @@ class SettlerDiscovererTest {
           "does not have public default constructor " +
           "[com.joom.colonist.processor.analysis.settlerdiscoverer.non_instantiable_by_supertype.PrivateConstructorSettler]"
     )
+  }
+
+  @Test
+  fun `kotlin objects selected by super type without no arg constructor produced via constructor do not raise an error`() {
+    rule.assertValidProject("kotlin_object_by_supertype")
   }
 
   @Test
@@ -137,6 +147,18 @@ class SettlerDiscovererTest {
   }
 
   @Test
+  fun `returns kotlin object settlers selected super type and produced via constructor`() {
+    val settlers = discoverSettlers(
+      sourceCodeDir = "kotlin_object_by_supertype",
+      selector = SettlerSelector.SuperType(computeType("kotlin_object_by_supertype", "TestSettler")),
+      producer = SettlerProducer.Constructor
+    )
+
+    settlers.shouldHaveSize(1)
+    settlers.shouldExist { it.type.className.endsWith("ObjectSettler") && it.isKotlinObject }
+  }
+
+  @Test
   fun `does not return abstract settlers selected by annotation and produced via constructor`() {
     val settlers = discoverSettlers(
       sourceCodeDir = "abstract_by_annotation",
@@ -173,6 +195,18 @@ class SettlerDiscovererTest {
     settlers.shouldExist { it.type.className.endsWith("AbstractSettler") }
     settlers.shouldExist { it.type.className.endsWith("InterfaceSettler") }
     settlers.shouldExist { it.type.className.endsWith("ConcreteSettler") }
+  }
+
+  @Test
+  fun `returns kotlin object settlers selected by annotation and produced via constructor`() {
+    val settlers = discoverSettlers(
+      sourceCodeDir = "kotlin_object_by_annotation",
+      selector = SettlerSelector.Annotation(computeType("kotlin_object_by_annotation", "TestSettler")),
+      producer = SettlerProducer.Constructor
+    )
+
+    settlers.shouldHaveSize(1)
+    settlers.shouldExist { it.type.className.endsWith("ObjectSettler") && it.isKotlinObject }
   }
 
   private fun discoverSettlers(sourceCodeDir: String, selector: SettlerSelector, producer: SettlerProducer): Collection<Settler> {

--- a/colonist/processor/src/test/java/com/joom/colonist/processor/analysis/SettlerParserTest.kt
+++ b/colonist/processor/src/test/java/com/joom/colonist/processor/analysis/SettlerParserTest.kt
@@ -1,0 +1,64 @@
+package com.joom.colonist.processor.analysis
+
+import com.joom.colonist.AcceptSettlersAndForget
+import com.joom.colonist.ProduceSettlersViaConstructor
+import com.joom.colonist.processor.integration.JvmRuntimeUtil
+import com.joom.colonist.processor.model.SettlerAcceptor
+import com.joom.colonist.processor.model.SettlerProducer
+import com.joom.grip.GripFactory
+import com.joom.grip.mirrors.getObjectType
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.nio.file.Path
+import java.nio.file.Paths
+import org.junit.Test
+
+class SettlerParserTest {
+
+  private val grip = GripFactory.INSTANCE.create(runtimeWithCurrentLocation())
+  private val parser = SettlerParserImpl(grip, SettlerProducerParserImpl, SettlerAcceptorParserImpl)
+
+  @Test
+  fun `parseSettler returns settler without overridden producer and acceptors`() {
+    val settler = parser.parseSettler(getObjectType<SettlerWithoutOverrides>())
+
+    settler.overriddenSettlerProducer.shouldBeNull()
+    settler.overriddenSettlerAcceptor.shouldBeNull()
+  }
+
+  @Test
+  fun `parseSettler returns annotated settler with overridden settler producer settler`() {
+    val settler = parser.parseSettler(getObjectType<OverriddenProducerSettler>())
+
+    settler.overriddenSettlerProducer.shouldBeInstanceOf<SettlerProducer.Constructor>()
+  }
+
+  @Test
+  fun `parseSettler returns annotated settler with overridden settler acceptor settler is annotated with`() {
+    val settler = parser.parseSettler(getObjectType<OverriddenAcceptorSettler>())
+
+    settler.overriddenSettlerAcceptor.shouldBeInstanceOf<SettlerAcceptor.None>()
+  }
+
+  @Test
+  fun `parseSettler returns kotlin object settler`() {
+    val settler = parser.parseSettler(getObjectType<KotlinObjectSettler>())
+
+    settler.isKotlinObject shouldBe true
+  }
+
+  private fun runtimeWithCurrentLocation(): Iterable<Path> {
+    return JvmRuntimeUtil.computeRuntimeClasspath() + listOf(Paths.get(javaClass.protectionDomain.codeSource.location.toURI()))
+  }
+
+  @ProduceSettlersViaConstructor
+  private class OverriddenProducerSettler
+
+  @AcceptSettlersAndForget
+  private class OverriddenAcceptorSettler
+
+  private class SettlerWithoutOverrides
+
+  private object KotlinObjectSettler
+}

--- a/colonist/processor/src/test/resources/com/joom/colonist/processor/analysis/settlerdiscoverer/kotlin_object_by_annotation/Configuration.kt
+++ b/colonist/processor/src/test/resources/com/joom/colonist/processor/analysis/settlerdiscoverer/kotlin_object_by_annotation/Configuration.kt
@@ -1,0 +1,27 @@
+package com.joom.colonist.processor.analysis.settlerdiscoverer.kotlin_object_by_annotation
+
+import com.joom.colonist.AcceptSettlersViaCallback
+import com.joom.colonist.Colony
+import com.joom.colonist.OnAcceptSettler
+import com.joom.colonist.ProduceSettlersViaConstructor
+import com.joom.colonist.SelectSettlersByAnnotation
+
+@TestSettler
+object ObjectSettler
+
+annotation class TestSettler
+
+@Colony
+@SelectSettlersByAnnotation(TestSettler::class)
+@ProduceSettlersViaConstructor
+@AcceptSettlersViaCallback
+annotation class TestColony
+
+@TestColony
+class TestColonyImpl {
+
+  @OnAcceptSettler(colonyAnnotation = TestColony::class)
+  fun onAcceptSettler(any: Any) {
+
+  }
+}

--- a/colonist/processor/src/test/resources/com/joom/colonist/processor/analysis/settlerdiscoverer/kotlin_object_by_supertype/Configuration.kt
+++ b/colonist/processor/src/test/resources/com/joom/colonist/processor/analysis/settlerdiscoverer/kotlin_object_by_supertype/Configuration.kt
@@ -1,0 +1,26 @@
+package com.joom.colonist.processor.analysis.settlerdiscoverer.kotlin_object_by_supertype
+
+import com.joom.colonist.AcceptSettlersViaCallback
+import com.joom.colonist.Colony
+import com.joom.colonist.OnAcceptSettler
+import com.joom.colonist.ProduceSettlersViaConstructor
+import com.joom.colonist.SelectSettlersBySuperType
+
+object ObjectSettler : TestSettler
+
+interface TestSettler
+
+@Colony
+@SelectSettlersBySuperType(TestSettler::class)
+@ProduceSettlersViaConstructor
+@AcceptSettlersViaCallback
+annotation class TestColony
+
+@TestColony
+class TestColonyImpl {
+
+  @OnAcceptSettler(colonyAnnotation = TestColony::class)
+  fun onAcceptSettler(any: Any) {
+
+  }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -11,6 +11,7 @@ ext {
   gripVersion = '0.9.0'
   logbackVersion = '1.2.11'
   kotestVersion = '5.3.0'
+  kotlinMetadata = '0.5.0'
 
   junitVersion = '4.13.2'
   androidxEspressoVersion = '3.4.0'


### PR DESCRIPTION
This PR introduces Kotlin object support, for settlers that produced via constructor.