### PR TITLE
Flag for enabling unit test processing

### DIFF
--- a/colonist-samples/modular-android/modular-app/build.gradle
+++ b/colonist-samples/modular-android/modular-app/build.gradle
@@ -27,6 +27,10 @@ android {
   }
 }
 
+colonist {
+  processTest = true
+}
+
 dependencies {
   implementation project(':colonist-samples:modular-android:modular-colony')
   for (feature in enabledFeatures.tokenize(',')) {

--- a/colonist-samples/modular-android/modular-app/src/test/java/com/joom/colonist/modular/FeatureManagerTest.kt
+++ b/colonist-samples/modular-android/modular-app/src/test/java/com/joom/colonist/modular/FeatureManagerTest.kt
@@ -16,13 +16,21 @@
 
 package com.joom.colonist.modular
 
-import com.joom.colonist.ColonistException
+import com.joom.colonist.modular.feature1.Feature1
+import com.joom.colonist.modular.feature2.Feature2
+import org.junit.Assert
 import org.junit.Test
 
 class FeatureManagerTest {
-  @Test(expected = ColonistException::class)
-  fun testFeatureManagerIsNotProcessed() {
-    // Unit tests aren't processed with the transform.
-    FeatureManager {}
+  @Test
+  fun testFeatureManagerIsProcessed() {
+    val features = ArrayList<Any>()
+    FeatureManager { feature ->
+      features += feature
+    }
+
+    Assert.assertEquals(2, features.size)
+    Assert.assertTrue(features.any { it is Feature1 })
+    Assert.assertTrue(features.any { it is Feature2 })
   }
 }

--- a/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/AndroidVariantColonistExtension.kt
+++ b/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/AndroidVariantColonistExtension.kt
@@ -1,0 +1,5 @@
+package com.joom.colonist.plugin
+
+open class AndroidVariantColonistExtension {
+  var processTest: Boolean = false
+}


### PR DESCRIPTION
Hi 👋
In our project, we want to run unit tests on classes collected with Colonist. The main idea is to check navigation destinations.
It would be convenient to have a "processTest" flag in the android plugin, similar to the java plugin.
So I added it in this pull request.