### PR TITLE
Kotlin 1.8.10 and Kotlin Metadata 0.6.0

### DIFF
--- a/colonist-samples/modular-android/modular-app/src/test/java/com/joom/colonist/modular/FeatureManagerTest.kt
+++ b/colonist-samples/modular-android/modular-app/src/test/java/com/joom/colonist/modular/FeatureManagerTest.kt
@@ -18,6 +18,7 @@ package com.joom.colonist.modular
 
 import com.joom.colonist.modular.feature1.Feature1
 import com.joom.colonist.modular.feature2.Feature2
+import com.joom.colonist.modular.feature3.Feature3
 import org.junit.Assert
 import org.junit.Test
 
@@ -29,8 +30,9 @@ class FeatureManagerTest {
       features += feature
     }
 
-    Assert.assertEquals(2, features.size)
+    Assert.assertEquals(3, features.size)
     Assert.assertTrue(features.any { it is Feature1 })
     Assert.assertTrue(features.any { it is Feature2 })
+    Assert.assertTrue(features.any { it is Feature3 })
   }
 }

--- a/colonist-samples/modular-android/modular-feature3/build.gradle
+++ b/colonist-samples/modular-android/modular-feature3/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+  compileSdkVersion androidCompileSdkVersion
+  buildToolsVersion androidBuildToolsVersion
+
+  defaultConfig {
+    minSdkVersion androidMinSdkVersion
+    targetSdkVersion androidTargetSdkVersion
+    versionCode 1
+    versionName version
+  }
+}
+
+dependencies {
+  implementation project(':colonist-samples:modular-android:modular-api')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+}

--- a/colonist-samples/modular-android/modular-feature3/src/main/AndroidManifest.xml
+++ b/colonist-samples/modular-android/modular-feature3/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright 2019 SIA Joom
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest package="com.joom.colonist.modular.feature3" />

--- a/colonist-samples/modular-android/modular-feature3/src/main/java/com/joom/colonist/modular/feature3/Feature3.kt
+++ b/colonist-samples/modular-android/modular-feature3/src/main/java/com/joom/colonist/modular/feature3/Feature3.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.modular.feature3
+
+import android.util.Log
+import com.joom.colonist.modular.api.Feature
+import com.joom.colonist.modular.api.FeatureSettler
+
+@FeatureSettler
+object Feature3 : Feature {
+
+  override fun activate() {
+    Log.i("Modular", "Feature3 activated")
+  }
+}

--- a/colonist-samples/sample-kotlin/build.gradle
+++ b/colonist-samples/sample-kotlin/build.gradle
@@ -18,8 +18,10 @@ jar {
   destinationDirectory.set(file('build/jar'))
 
   from {
-    configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
   }
+
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 colonist {

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/commons/MirrorsExtensions.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/commons/MirrorsExtensions.kt
@@ -24,8 +24,8 @@ import com.joom.grip.mirrors.ClassMirror
 import com.joom.grip.mirrors.FieldMirror
 import com.joom.grip.mirrors.MethodMirror
 import kotlinx.metadata.Flag
-import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.Metadata
 
 fun MethodMirror.toMethodDescriptor(): MethodDescriptor {
   return MethodDescriptor(name, type)
@@ -38,17 +38,17 @@ fun FieldMirror.toFieldDescriptor(): FieldDescriptor {
 fun ClassMirror.isKotlinObject(): Boolean {
   val metadata = annotations[Types.KOTLIN_METADATA_TYPE] ?: return false
 
-  val header = KotlinClassHeader(
-    kind = metadata.optionalValue("k"),
-    metadataVersion = metadata.requireValue("mv"),
-    data1 = metadata.optionalValue<List<String>>("d1")?.toTypedArray(),
-    data2 = metadata.optionalValue<List<String>>("d2")?.toTypedArray(),
-    extraString = metadata.optionalValue("xs"),
-    packageName = metadata.optionalValue("pn"),
-    extraInt = metadata.optionalValue("xi"),
+  val classMetadata = KotlinClassMetadata.read(
+    Metadata(
+      kind = metadata.optionalValue("k"),
+      metadataVersion = metadata.requireValue("mv"),
+      data1 = metadata.optionalValue<List<String>>("d1")?.toTypedArray(),
+      data2 = metadata.optionalValue<List<String>>("d2")?.toTypedArray(),
+      extraString = metadata.optionalValue("xs"),
+      packageName = metadata.optionalValue("pn"),
+      extraInt = metadata.optionalValue("xi"),
+    )
   )
-
-  val classMetadata = KotlinClassMetadata.read(header)
 
   return if (classMetadata is KotlinClassMetadata.Class) {
     Flag.Class.IS_OBJECT(classMetadata.toKmClass().flags)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-enabledFeatures=feature1,feature2
+enabledFeatures=feature1,feature2,feature3
 development=true
 pablo.shadow.enabled=false
 kotlin.incremental=true

--- a/versions.gradle
+++ b/versions.gradle
@@ -3,7 +3,7 @@ ext.COLONIST_VERSION = "0.1.0-alpha20"
 
 ext {
   javaVersion = JavaVersion.VERSION_1_8
-  kotlinVersion = '1.6.10'
+  kotlinVersion = '1.8.10'
   pabloVersion = '1.3.1'
 
   jsr305Version = '3.0.2'
@@ -11,7 +11,7 @@ ext {
   gripVersion = '0.9.0'
   logbackVersion = '1.2.11'
   kotestVersion = '5.3.0'
-  kotlinMetadata = '0.5.0'
+  kotlinMetadata = '0.6.0'
 
   junitVersion = '4.13.2'
   androidxEspressoVersion = '3.4.0'


### PR DESCRIPTION
It looks like `Kotlin Metadata 0.5.0` doesn't work properly when processing classes generated by the latest (1.8.10) Kotlin version.