### PR TITLE
Android Gradle plugin 8.x.x support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Publish bootstrap artifacts
         run: ./gradlew -p colonist check publishToMavenLocal ${{ env.PABLO_OPTS }}
@@ -63,7 +63,7 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Publish bootstrap artifacts
         run: ./gradlew -p colonist check publishToMavenLocal ${{ env.PABLO_OPTS }}
@@ -94,7 +94,7 @@ jobs:
       - name: Configure JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Upload Artifacts
         run: ./gradlew -p colonist publishToSonatype ${{ env.PABLO_OPTS }}

--- a/colonist/build.gradle
+++ b/colonist/build.gradle
@@ -1,3 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
   apply from: '../versions.gradle'
 
@@ -40,10 +44,11 @@ allprojects {
   apply plugin: "org.jlleitschuh.gradle.ktlint"
 
   gradle.projectsEvaluated {
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-      kotlinOptions {
-        jvmTarget = "1.8"
-        allWarningsAsErrors = true
+    tasks.withType(KotlinCompile).configureEach {
+      compilerOptions {
+        jvmTarget.set(JvmTarget["Companion"].fromTarget(javaVersion.toString()))
+        apiVersion.set(KotlinVersion["Companion"].fromVersion(kotlinLanguageVersion))
+        languageVersion.set(KotlinVersion["Companion"].fromVersion(kotlinLanguageVersion))
       }
     }
   }

--- a/colonist/build.gradle
+++ b/colonist/build.gradle
@@ -45,11 +45,7 @@ allprojects {
 
   gradle.projectsEvaluated {
     tasks.withType(KotlinCompile).configureEach {
-      compilerOptions {
-        jvmTarget.set(JvmTarget["Companion"].fromTarget(javaVersion.toString()))
-        apiVersion.set(KotlinVersion["Companion"].fromVersion(kotlinLanguageVersion))
-        languageVersion.set(KotlinVersion["Companion"].fromVersion(kotlinLanguageVersion))
-      }
+      setCompilerOptions(it)
     }
   }
 }
@@ -92,5 +88,17 @@ afterEvaluate {
     subprojects.each {
       dependsOn(it.tasks.named("publishToMavenLocal"))
     }
+  }
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  setCompilerOptions(it)
+}
+
+def setCompilerOptions(KotlinCompile task) {
+  task.compilerOptions {
+    jvmTarget.set(JvmTarget["Companion"].fromTarget(javaVersion.toString()))
+    apiVersion.set(KotlinVersion["Companion"].fromVersion(kotlinLanguageVersion))
+    languageVersion.set(KotlinVersion["Companion"].fromVersion(kotlinLanguageVersion))
   }
 }

--- a/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/AllClassesTransformRegistrar.kt
+++ b/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/AllClassesTransformRegistrar.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.plugin
+
+import com.android.build.api.artifact.MultipleArtifact
+import com.android.build.api.variant.Component
+import org.gradle.api.tasks.TaskProvider
+
+internal object AllClassesTransformRegistrar : TransformTaskRegistrar {
+  override fun register(component: Component, taskProvider: TaskProvider<ColonistTransformClassesTask>) {
+    @Suppress("DEPRECATION")
+    component.artifacts.use(taskProvider)
+      .wiredWith(ColonistTransformClassesTask::inputDirectories, ColonistTransformClassesTask::outputDirectory)
+      .toTransform(MultipleArtifact.ALL_CLASSES_DIRS)
+  }
+}

--- a/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/ColonistTask.kt
+++ b/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/ColonistTask.kt
@@ -16,6 +16,7 @@
 
 package com.joom.colonist.plugin
 
+import com.joom.colonist.processor.ColonistOutputFactory
 import com.joom.colonist.processor.ColonistParameters
 import com.joom.colonist.processor.ColonistProcessor
 import com.joom.colonist.processor.watermark.WatermarkChecker
@@ -59,12 +60,13 @@ open class ColonistTask : DefaultTask() {
   fun process() {
     validate()
 
+    val inputPaths = backupDirs.map { it.toPath() }
+    val outputPaths = classesDirs.map { it.toPath() }
     val parameters = ColonistParameters(
-      inputs = backupDirs.map { it.toPath() },
-      outputs = classesDirs.map { it.toPath() },
+      inputs = inputPaths,
+      outputFactory = ColonistOutputFactory.create(inputPaths, outputPaths, outputPaths.first()),
       classpath = classpath.map { it.toPath() },
       discoveryClasspath = classpath.map { it.toPath() },
-      generationOutput = classesDirs.first().toPath(),
       bootClasspath = bootClasspath.map { it.toPath() },
       discoverSettlers = discoverSettlers,
     )

--- a/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/ScopedArtifactsRegistrar.kt
+++ b/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/ScopedArtifactsRegistrar.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.plugin
+
+import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.variant.Component
+import com.android.build.api.variant.ScopedArtifacts
+import org.gradle.api.tasks.TaskProvider
+
+internal object ScopedArtifactsRegistrar : TransformTaskRegistrar {
+  override fun register(component: Component, taskProvider: TaskProvider<ColonistTransformClassesTask>) {
+    component.artifacts.forScope(ScopedArtifacts.Scope.PROJECT)
+      .use(taskProvider)
+      .toTransform(
+        ScopedArtifact.CLASSES,
+        ColonistTransformClassesTask::inputClasses,
+        ColonistTransformClassesTask::inputDirectories,
+        ColonistTransformClassesTask::output
+      )
+  }
+}

--- a/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/TransformTaskRegistrar.kt
+++ b/colonist/gradle-plugin/src/main/java/com/joom/colonist/plugin/TransformTaskRegistrar.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.plugin
+
+import com.android.build.api.variant.Component
+import org.gradle.api.tasks.TaskProvider
+
+internal interface TransformTaskRegistrar {
+  fun register(component: Component, taskProvider: TaskProvider<ColonistTransformClassesTask>)
+}

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/ColonistOutput.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/ColonistOutput.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.processor
+
+import com.joom.colonist.processor.commons.associateByIndexedTo
+import com.joom.colonist.processor.commons.closeQuietly
+import com.joom.grip.io.FileSink
+import java.io.Closeable
+import java.nio.file.Path
+
+interface ColonistOutput : Closeable {
+  fun getFileSink(input: Path): FileSink
+  fun getGenerationSink(): FileSink
+}
+
+internal class MultipleSinkOutput(private val inputs: List<Path>, private val outputs: List<Path>, generationPath: Path) : ColonistOutput {
+  init {
+    require(inputs.size == outputs.size) { "Inputs size should be equal to outputs size" }
+  }
+
+  private val generationSink = createFileSink(generationPath)
+  private val sinksByInputs = HashMap<Path, FileSink>().also {
+    inputs.associateByIndexedTo(it, { _, input -> input }, { index, _ -> createFileSink(outputs[index]) })
+  }
+
+  override fun getFileSink(input: Path): FileSink {
+    return sinksByInputs[input] ?: error("Failed to create file sink for input $input")
+  }
+
+  override fun getGenerationSink(): FileSink {
+    return generationSink
+  }
+
+  override fun close() {
+    generationSink.closeQuietly()
+    sinksByInputs.forEach { (_, sink) ->
+      sink.closeQuietly()
+    }
+  }
+}
+
+internal class SingleSinkOutput(path: Path) : ColonistOutput {
+  private var sink = createFileSink(path)
+
+  override fun getFileSink(input: Path): FileSink {
+    return sink
+  }
+
+  override fun getGenerationSink(): FileSink {
+    return sink
+  }
+
+  override fun close() {
+    sink.closeQuietly()
+  }
+}

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/ColonistOutputFactory.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/ColonistOutputFactory.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.processor
+
+import java.nio.file.Path
+
+interface ColonistOutputFactory {
+  fun createOutput(): ColonistOutput
+
+  companion object {
+    fun create(output: Path): ColonistOutputFactory {
+      return SingleSinkOutputProvider(output)
+    }
+
+    fun create(inputs: List<Path>, outputs: List<Path>, generationPath: Path): ColonistOutputFactory {
+      require(inputs.size == outputs.size) { "Inputs size should be equal to outputs size" }
+
+      return MultipleSinkOutputProvider(inputs, outputs, generationPath)
+    }
+  }
+}
+
+internal class SingleSinkOutputProvider(
+  private val output: Path,
+) : ColonistOutputFactory {
+  override fun createOutput(): ColonistOutput {
+    return SingleSinkOutput(output)
+  }
+}
+
+internal class MultipleSinkOutputProvider(
+  private val inputs: List<Path>,
+  private val outputs: List<Path>,
+  private val generationPath: Path,
+) : ColonistOutputFactory {
+  override fun createOutput(): ColonistOutput {
+    return MultipleSinkOutput(inputs, outputs, generationPath)
+  }
+}

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/ColonistParameters.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/ColonistParameters.kt
@@ -19,9 +19,8 @@ package com.joom.colonist.processor
 import java.nio.file.Path
 
 data class ColonistParameters(
+  val outputFactory: ColonistOutputFactory,
   val inputs: List<Path>,
-  val outputs: List<Path>,
-  val generationOutput: Path,
   val discoveryClasspath: List<Path>,
   val classpath: List<Path>,
   val bootClasspath: List<Path>,

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/FileSinkFactory.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/FileSinkFactory.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.processor
+
+import com.joom.grip.io.DirectoryFileSink
+import com.joom.grip.io.EmptyFileSink
+import com.joom.grip.io.FileSink
+import com.joom.grip.io.JarFileSink
+import java.nio.file.Path
+import java.util.Collections
+import kotlin.io.path.exists
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+
+internal fun createFileSink(outputFile: Path): FileSink {
+  return when (outputFile.sourceType) {
+    FileType.EMPTY -> EmptyFileSink
+    FileType.DIRECTORY -> DirectoryFileSink(outputFile)
+    FileType.JAR -> PatchedJarFileSink(JarFileSink(outputFile)).synchronized()
+  }
+}
+
+private class PatchedJarFileSink(private val delegate: FileSink) : FileSink by delegate {
+  private val directories = Collections.synchronizedSet(HashSet<String>())
+
+  override fun createDirectory(path: String) {
+    if (directories.add(path)) {
+      delegate.createDirectory(path)
+    }
+  }
+}
+
+private val Path.sourceType: FileType
+  get() = when {
+    extension.endsWith("jar", ignoreCase = true) -> FileType.JAR
+    !exists() || isDirectory() -> FileType.DIRECTORY
+    else -> error("Unknown source type for file $this")
+  }
+
+private enum class FileType {
+  EMPTY,
+  DIRECTORY,
+  JAR,
+}
+
+private fun FileSink.synchronized(): FileSink {
+  return if (this !is SynchronizedFileSink) SynchronizedFileSink(this) else this
+}
+
+private class SynchronizedFileSink(private val delegate: FileSink) : FileSink by delegate {
+  private val lock = Any()
+  override fun createFile(path: String, data: ByteArray) {
+    synchronized(lock) {
+      delegate.createFile(path, data)
+    }
+  }
+
+  override fun createDirectory(path: String) {
+    synchronized(lock) {
+      delegate.createDirectory(path)
+    }
+  }
+
+  override fun close() {
+    synchronized(lock) {
+      delegate.close()
+    }
+  }
+
+  override fun flush() {
+    synchronized(lock) {
+      delegate.flush()
+    }
+  }
+}

--- a/colonist/processor/src/main/java/com/joom/colonist/processor/commons/IterableExtensions.kt
+++ b/colonist/processor/src/main/java/com/joom/colonist/processor/commons/IterableExtensions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.processor.commons
+
+inline fun <T, K, V, M : MutableMap<in K, in V>> Iterable<T>.associateByIndexedTo(
+  destination: M,
+  keySelector: (Int, T) -> K,
+  valueSelector: (Int, T) -> V
+): M {
+  forEachIndexed { index, element ->
+    destination.put(keySelector(index, element), valueSelector(index, element))
+  }
+  return destination
+}

--- a/colonist/processor/src/test/java/com/joom/colonist/processor/MultipleSinkOutputTest.kt
+++ b/colonist/processor/src/test/java/com/joom/colonist/processor/MultipleSinkOutputTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.processor
+
+import java.nio.file.Path
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MultipleSinkOutputTest {
+
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `getFileSink returns same instance per input`() {
+    val firstInput = temporaryFolder.newFile().toPath()
+    val secondInput = temporaryFolder.newFile().toPath()
+
+    createOutput(
+      inputs = listOf(firstInput, secondInput),
+    ).use { output ->
+      val firstSink = output.getFileSink(firstInput)
+      val secondSink = output.getFileSink(secondInput)
+
+      Assert.assertNotSame(firstSink, secondSink)
+      Assert.assertSame(firstSink, output.getFileSink(firstInput))
+      Assert.assertSame(secondSink, output.getFileSink(secondInput))
+    }
+  }
+
+  @Test
+  fun `getGenerationSink returns the same instance`() {
+    val path = temporaryFolder.newFolder().toPath()
+    SingleSinkOutput(path).use { output ->
+      val inputSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val generationSink = output.getGenerationSink()
+
+      Assert.assertSame(inputSink, generationSink)
+    }
+  }
+
+  private fun createOutput(inputs: List<Path>): MultipleSinkOutput {
+    return MultipleSinkOutput(
+      inputs = inputs,
+      outputs = List(inputs.size) { temporaryFolder.newFolder().toPath() },
+      generationPath = temporaryFolder.newFolder().toPath()
+    )
+  }
+}

--- a/colonist/processor/src/test/java/com/joom/colonist/processor/SingleSinkOutputTest.kt
+++ b/colonist/processor/src/test/java/com/joom/colonist/processor/SingleSinkOutputTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.colonist.processor
+
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SingleSinkOutputTest {
+
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `getFileSink returns the same instance for different inputs`() {
+    val path = temporaryFolder.newFolder().toPath()
+    SingleSinkOutput(path).use { output ->
+      val firstSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val secondSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val thirdSink = output.getFileSink(temporaryFolder.newFile().toPath())
+
+      Assert.assertSame(firstSink, secondSink)
+      Assert.assertSame(secondSink, thirdSink)
+    }
+  }
+
+  @Test
+  fun `getGenerationSink returns the same instance`() {
+    val path = temporaryFolder.newFolder().toPath()
+    SingleSinkOutput(path).use { output ->
+      val inputSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val generationSink = output.getGenerationSink()
+
+      Assert.assertSame(inputSink, generationSink)
+    }
+  }
+}

--- a/colonist/processor/src/test/java/com/joom/colonist/processor/integration/IntegrationTestRule.kt
+++ b/colonist/processor/src/test/java/com/joom/colonist/processor/integration/IntegrationTestRule.kt
@@ -16,6 +16,7 @@
 
 package com.joom.colonist.processor.integration
 
+import com.joom.colonist.processor.ColonistOutputFactory
 import com.joom.colonist.processor.ColonistParameters
 import com.joom.colonist.processor.ColonistProcessor
 import com.joom.colonist.processor.ErrorReporter
@@ -93,11 +94,10 @@ class IntegrationTestRule(
     val outputDirectory = processedDirectory.resolve(projectName)
     val parameters = ColonistParameters(
       inputs = listOf(compiled),
-      outputs = listOf(outputDirectory),
+      outputFactory = ColonistOutputFactory.create(outputDirectory),
       bootClasspath = classpath,
       discoveryClasspath = modules,
       classpath = emptyList(),
-      generationOutput = outputDirectory,
       discoverSettlers = discoverSettlers,
     )
 

--- a/colonist/src/functionalTest/java/com/joom/colonist/plugin/AndroidColonistPluginTest.kt
+++ b/colonist/src/functionalTest/java/com/joom/colonist/plugin/AndroidColonistPluginTest.kt
@@ -43,6 +43,7 @@ internal class AndroidColonistPluginTest(private val case: TestCase) {
       return listOf(
         TestCase(agpVersion = "7.0.4", GradleDistribution.GRADLE_7_5, expectedTaskName = ":transformClassesWithColonistForDebug"),
         TestCase(agpVersion = "7.2.0", GradleDistribution.GRADLE_7_5, expectedTaskName = ":colonistTransformClassesDebug"),
+        TestCase(agpVersion = "8.1.2", GradleDistribution.GRADLE_8_0, expectedTaskName = ":colonistTransformClassesDebug"),
       )
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Oct 02 16:52:36 WEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/versions.gradle
+++ b/versions.gradle
@@ -2,7 +2,8 @@ ext.COLONIST_GROUP = "com.joom.colonist"
 ext.COLONIST_VERSION = "0.1.0-alpha21"
 
 ext {
-  javaVersion = JavaVersion.VERSION_1_8
+  javaVersion = JavaVersion.VERSION_11
+  kotlinLanguageVersion = '1.7'
   kotlinVersion = '1.8.10'
   pabloVersion = '1.3.1'
 
@@ -23,7 +24,7 @@ ext {
   androidTargetSdkVersion = 30
   androidMinSdkVersion = 16
   androidBuildToolsVersion = '30.0.3'
-  androidToolsVersion = '7.1.0'
+  androidToolsVersion = '7.4.2'
 
   androidxAnnotationVersion = '1.2.0'
 }


### PR DESCRIPTION
Mostly copy-pasted code from [Lightsaber plugin](https://github.com/joomcode/lightsaber/pull/26) with the same approach:

Instead of using output directories directly, plugin uses `ColonistOutput`, that hides implementation details across different AGP API versions.
